### PR TITLE
backstab nerf

### DIFF
--- a/cmd/combat_backstab.go
+++ b/cmd/combat_backstab.go
@@ -101,8 +101,8 @@ func (backstab) process(s *state) {
 		if lvlDiff > 1 {
 			lvlDiff = (lvlDiff - 1) * .125
 			curChance -= int(float64(curChance) * lvlDiff)
-		} else {
-			curChance += int(lvlDiff * float64(config.BackStabChancePerLevel) * -1)
+		} else if lvlDiff == 1 {
+			curChance -= config.BackStabChancePerLevel
 		}
 
 		//s.msg.Actor.SendInfo("BS chance = " + strconv.Itoa(curChance))


### PR DESCRIPTION
Backstab is too strong vs mobs lower level then the player. No more bonus for being higher level then mob. This is how stealing and regular attack miss chance works